### PR TITLE
Fixed misspelling “Recipies” —> category_octopus_screen.dart

### DIFF
--- a/lib/screens/category_octopus_screen.dart
+++ b/lib/screens/category_octopus_screen.dart
@@ -47,7 +47,7 @@ class _CategoryOctopusScreenState extends State<CategoryOctopusScreen> {
               alignment: Alignment.centerLeft,
               child: RichText(
                 text: TextSpan(
-                  text: "8 different recipies for ",
+                  text: "8 different recipes for ",
                   style: TextStyle(
                     fontSize: 22,
                     color: Colors.black,


### PR DESCRIPTION
Fixed the misspelling “recipies” —> “recipes”
Found on Line 50